### PR TITLE
Fix text not showing up on macOS

### DIFF
--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
@@ -269,14 +269,11 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
 			context.drawGuiTexture(textureId, getX(), getY(), getWidth(), getHeight());
 		}
 
-		Window window = MinecraftClient.getInstance().getWindow();
-		double scaleFactor = window.getScaleFactor();
-		RenderSystem.enableScissor(
-			(int)Math.round((this.getX() + 1) * scaleFactor),
-			// OpenGL coordinates start from the bottom left.
-			window.getHeight() - (int)Math.round((this.getY() + 1) * scaleFactor + this.height * scaleFactor),
-			(int)Math.round((this.width - 2) * scaleFactor),
-			(int)Math.round((this.height - 2) * scaleFactor)
+		context.enableScissor(
+			this.getX() + 1,
+			this.getY() + 1,
+			this.getX() + this.getWidth() - 1,
+			this.getY() + this.getHeight() - 1
 		);
 
 		int textColor = self.invokeIsEditable() ? self.getEditableColor() : self.getUneditableColor();
@@ -324,7 +321,7 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
 			renderSelection(context, x, y);
 		}
 
-		RenderSystem.disableScissor();
+		context.disableScissor();
 	}
 
 	private void renderSelection(DrawContext context, int x, int y) {


### PR DESCRIPTION
Solves https://github.com/arm32x/command-block-ide/issues/40

I was looking into this issue and realized removing the scissor call made the text show up, so I looked into minecraft's code to see where they used `RenderSystem.enableScissor` and I realized they use it just once in a wrapper method in `DrawContext` surely enough, using that helper method completely resolved the issue, while maintaining the scissor effect for long lines.

It likely already accounts for os differences or something, I didn't look too deeply into it though. The resulting code is much cleaner imo.