### PR TITLE
Update to Java 21 & 1.20.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
     withSourcesJar()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx2G
 # Gradle Plugins
 android_git_version_version=0.4.14
-loom_version=1.4-SNAPSHOT
+loom_version=1.6-SNAPSHOT
 shadow_version=7.1.2
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
-loader_version=0.15.3
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.1
+loader_version=0.15.10
 # Dependencies
 # check these on https://modmuss50.me/fabric.html
-fabric_version=0.91.3+1.20.4
+fabric_version=0.97.8+1.20.6
 msgpack_java_version=0.9.3
 # Test dependencies
 junit_version=5.9.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/arm32x/minecraft/commandblockide/CommandBlockIDE.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/CommandBlockIDE.java
@@ -25,9 +25,8 @@ import org.apache.logging.log4j.Logger;
 public final class CommandBlockIDE implements ModInitializer {
 	@Override
 	public void onInitialize() {
-		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
-			EditFunctionCommand.register(dispatcher);
-		});
+		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
+				EditFunctionCommand.register(dispatcher));
 
 		final PacketMerger functionMerger = new PacketMerger();
 		PayloadTypeRegistry.playC2S().register(Packets.APPLY_FUNCTION, ApplyFunctionPayload.CODEC);

--- a/src/main/java/arm32x/minecraft/commandblockide/CommandBlockIDE.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/CommandBlockIDE.java
@@ -1,6 +1,7 @@
 package arm32x.minecraft.commandblockide;
 
 import arm32x.minecraft.commandblockide.mixinextensions.server.CommandFunctionExtension;
+import arm32x.minecraft.commandblockide.payloads.ApplyFunctionPayload;
 import arm32x.minecraft.commandblockide.server.command.EditFunctionCommand;
 import arm32x.minecraft.commandblockide.server.function.FunctionIO;
 import arm32x.minecraft.commandblockide.util.PacketMerger;
@@ -9,11 +10,13 @@ import java.util.List;
 import java.util.Optional;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.function.CommandFunction;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
@@ -27,12 +30,13 @@ public final class CommandBlockIDE implements ModInitializer {
 		});
 
 		final PacketMerger functionMerger = new PacketMerger();
-		ServerPlayNetworking.registerGlobalReceiver(Packets.APPLY_FUNCTION, (server, player, handler, buf, responseSender) -> {
+		PayloadTypeRegistry.playC2S().register(Packets.APPLY_FUNCTION, ApplyFunctionPayload.CODEC);
+		ServerPlayNetworking.registerGlobalReceiver(Packets.APPLY_FUNCTION, (payload, context) -> {
 			Optional<PacketByteBuf> maybeMerged = Optional.empty();
 			try {
-				maybeMerged = functionMerger.append(buf);
+				maybeMerged = functionMerger.append(payload.toBuf());
 			} catch (PacketMerger.InvalidSplitPacketException e) {
-				e.printStackTrace();
+				LOGGER.error("PacketMerger", e);
 			}
 			if (maybeMerged.isPresent()) {
 				PacketByteBuf merged = maybeMerged.get();
@@ -43,6 +47,8 @@ public final class CommandBlockIDE implements ModInitializer {
 					lines[index] = merged.readString(Integer.MAX_VALUE >> 2);
 				}
 
+				ServerPlayerEntity player = context.player();
+				MinecraftServer server = player.server;
 				server.execute(() -> {
 					Text feedbackMessage = FunctionIO.saveFunction(server, functionId, Arrays.asList(lines));
 					player.sendMessage(feedbackMessage);

--- a/src/main/java/arm32x/minecraft/commandblockide/Packets.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/Packets.java
@@ -1,12 +1,20 @@
 package arm32x.minecraft.commandblockide;
 
-import net.minecraft.util.Identifier;
+import arm32x.minecraft.commandblockide.payloads.ApplyFunctionPayload;
+import arm32x.minecraft.commandblockide.payloads.EditFunctionPayload;
+import arm32x.minecraft.commandblockide.payloads.UpdateFunctionCommandPayload;
+import net.minecraft.network.packet.CustomPayload;
+
+import static net.minecraft.network.packet.CustomPayload.Id;
 
 public final class Packets {
+	// Namespace
+	private static final String NAMESPACE = "commandblockide";
+
 	// Client to Server
-	public static final Identifier APPLY_FUNCTION = new Identifier("commandblockide", "apply_function");
+	public static final Id<ApplyFunctionPayload> APPLY_FUNCTION = CustomPayload.id(NAMESPACE + ":apply_function");
 
 	// Server to Client
-	public static final Identifier EDIT_FUNCTION = new Identifier("commandblockide", "edit_function");
-	public static final Identifier UPDATE_FUNCTION_COMMAND = new Identifier("commandblockide", "update_function_command");
+	public static final Id<EditFunctionPayload> EDIT_FUNCTION = CustomPayload.id(NAMESPACE + ":edit_function");
+	public static final Id<UpdateFunctionCommandPayload> UPDATE_FUNCTION_COMMAND = CustomPayload.id(NAMESPACE + ":update_function_command");
 }

--- a/src/main/java/arm32x/minecraft/commandblockide/client/CommandChainTracer.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/CommandChainTracer.java
@@ -1,14 +1,14 @@
 package arm32x.minecraft.commandblockide.client;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.CommandBlock;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+
+import java.util.*;
+import java.util.stream.Stream;
 
 public final class CommandChainTracer {
 	private final ClientWorld world;
@@ -117,7 +117,7 @@ public final class CommandChainTracer {
 				if (results.size() != 1) {
 					throw new NoSuchElementException();
 				}
-				position = results.get(0);
+				position = results.getFirst();
 				visited.add(position);
 				return position;
 			}

--- a/src/main/java/arm32x/minecraft/commandblockide/client/CommandChainTracer.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/CommandChainTracer.java
@@ -113,7 +113,7 @@ public final class CommandChainTracer {
 					Blocks.REPEATING_COMMAND_BLOCK,
 					Blocks.CHAIN_COMMAND_BLOCK
 				).anyMatch(blockState::isOf)) {
-				List<BlockPos> results = getStream(blockState).collect(Collectors.toList());
+				List<BlockPos> results = getStream(blockState).toList();
 				if (results.size() != 1) {
 					throw new NoSuchElementException();
 				}

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
@@ -3,17 +3,8 @@ package arm32x.minecraft.commandblockide.client.gui;
 import arm32x.minecraft.commandblockide.mixin.client.EditBoxAccessor;
 import arm32x.minecraft.commandblockide.mixin.client.TextFieldWidgetAccessor;
 import arm32x.minecraft.commandblockide.util.OrderedTexts;
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.EditBox;
@@ -21,8 +12,8 @@ import net.minecraft.client.gui.screen.ChatInputSuggestor;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.input.CursorMovement;
-import net.minecraft.client.render.*;
-import net.minecraft.client.util.Window;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
@@ -33,6 +24,13 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.lwjgl.glfw.GLFW;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 @Environment(EnvType.CLIENT)
 public class MultilineTextFieldWidget extends TextFieldWidget {

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/editor/CommandBlockEditor.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/editor/CommandBlockEditor.java
@@ -109,7 +109,7 @@ public final class CommandBlockEditor extends CommandEditor {
 		trackOutputButton.setTrackingOutput(executor.isTrackingOutput());
 
 		String lastOutput = executor.getLastOutput().getString();
-		if (lastOutput.equals("")) {
+		if (lastOutput.isEmpty()) {
 			lastOutput = Text.translatable("commandBlockIDE.lastOutput.none").getString();
 		}
 		lastOutputField.setText(lastOutput);

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/screen/CommandFunctionIDEScreen.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/screen/CommandFunctionIDEScreen.java
@@ -1,9 +1,10 @@
 package arm32x.minecraft.commandblockide.client.gui.screen;
 
-import arm32x.minecraft.commandblockide.Packets;
 import arm32x.minecraft.commandblockide.client.gui.editor.CommandEditor;
 import arm32x.minecraft.commandblockide.client.gui.editor.CommandFunctionEditor;
+import arm32x.minecraft.commandblockide.payloads.ApplyFunctionPayload;
 import arm32x.minecraft.commandblockide.util.PacketSplitter;
+import io.netty.buffer.ByteBuf;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.network.PacketByteBuf;
@@ -59,8 +60,9 @@ public final class CommandFunctionIDEScreen extends CommandIDEScreen<CommandFunc
 		PacketSplitter.updateChunkCount(buf);
 
 		PacketSplitter splitter = new PacketSplitter(buf);
-		for (PacketByteBuf splitBuf : splitter) {
-			ClientPlayNetworking.send(Packets.APPLY_FUNCTION, splitBuf);
+		for (ByteBuf splitBuf : splitter) {
+			ClientPlayNetworking.send(new ApplyFunctionPayload(splitBuf));
+//			ClientPlayNetworking.send(Packets.APPLY_FUNCTION, splitBuf);
 		}
 
 		super.save();

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/screen/CommandFunctionIDEScreen.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/screen/CommandFunctionIDEScreen.java
@@ -62,7 +62,6 @@ public final class CommandFunctionIDEScreen extends CommandIDEScreen<CommandFunc
 		PacketSplitter splitter = new PacketSplitter(buf);
 		for (ByteBuf splitBuf : splitter) {
 			ClientPlayNetworking.send(new ApplyFunctionPayload(splitBuf));
-//			ClientPlayNetworking.send(Packets.APPLY_FUNCTION, splitBuf);
 		}
 
 		super.save();

--- a/src/main/java/arm32x/minecraft/commandblockide/client/update/DataCommandUpdateRequester.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/update/DataCommandUpdateRequester.java
@@ -86,7 +86,7 @@ public final class DataCommandUpdateRequester {
 			return false;
 		}
 
-		blockEntity.readNbt(tag);
+		blockEntity.readNbt(tag, client.world.getRegistryManager());
 //		blockEntity.setNeedsUpdatePacket(false);
 		if (client.currentScreen instanceof CommandBlockIDEScreen) {
 			((CommandBlockIDEScreen)client.currentScreen).update(position);

--- a/src/main/java/arm32x/minecraft/commandblockide/payloads/ApplyFunctionPayload.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/payloads/ApplyFunctionPayload.java
@@ -1,0 +1,28 @@
+package arm32x.minecraft.commandblockide.payloads;
+
+import arm32x.minecraft.commandblockide.Packets;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public record ApplyFunctionPayload(ByteBuf bytes) implements CustomPayload {
+    public static final PacketCodec<PacketByteBuf, ApplyFunctionPayload> CODEC = PacketCodec.of(ApplyFunctionPayload::send, ApplyFunctionPayload::new);
+
+    public ApplyFunctionPayload(PacketByteBuf buf) {
+        this(buf.readBytes(buf.readableBytes()));
+    }
+
+    private void send(PacketByteBuf buf) {
+        buf.writeBytes(bytes, bytes.readableBytes());
+    }
+
+    public PacketByteBuf toBuf() {
+        return new PacketByteBuf(bytes);
+    }
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return Packets.APPLY_FUNCTION;
+    }
+}

--- a/src/main/java/arm32x/minecraft/commandblockide/payloads/EditFunctionPayload.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/payloads/EditFunctionPayload.java
@@ -1,0 +1,25 @@
+package arm32x.minecraft.commandblockide.payloads;
+
+import arm32x.minecraft.commandblockide.Packets;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record EditFunctionPayload(Identifier id, int lineCount) implements CustomPayload {
+    public static final PacketCodec<PacketByteBuf, EditFunctionPayload> CODEC = PacketCodec.of(EditFunctionPayload::send, EditFunctionPayload::new);
+
+    public EditFunctionPayload(PacketByteBuf buf) {
+        this(buf.readIdentifier(), buf.readVarInt());
+    }
+
+    private void send(PacketByteBuf buf) {
+        buf.writeIdentifier(id);
+        buf.writeVarInt(lineCount);
+    }
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return Packets.EDIT_FUNCTION;
+    }
+}

--- a/src/main/java/arm32x/minecraft/commandblockide/payloads/UpdateFunctionCommandPayload.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/payloads/UpdateFunctionCommandPayload.java
@@ -1,0 +1,24 @@
+package arm32x.minecraft.commandblockide.payloads;
+
+import arm32x.minecraft.commandblockide.Packets;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public record UpdateFunctionCommandPayload(int index, String line) implements CustomPayload {
+    public static final PacketCodec<PacketByteBuf, UpdateFunctionCommandPayload> CODEC = PacketCodec.of(UpdateFunctionCommandPayload::send, UpdateFunctionCommandPayload::new);
+
+    public UpdateFunctionCommandPayload(PacketByteBuf buf) {
+        this(buf.readVarInt(), buf.readString());
+    }
+
+    private void send(PacketByteBuf buf) {
+        buf.writeVarInt(index);
+        buf.writeString(line); // TODO: Make sure this doesn’t exceed size limits.
+    }
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return Packets.UPDATE_FUNCTION_COMMAND;
+    }
+}

--- a/src/main/java/arm32x/minecraft/commandblockide/util/PacketSplitter.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/util/PacketSplitter.java
@@ -2,13 +2,15 @@ package arm32x.minecraft.commandblockide.util;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import io.netty.buffer.ByteBuf;
 import net.minecraft.network.PacketByteBuf;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Splits a {@link PacketByteBuf} into several chunks to avoid size limitations.
  */
-public final class PacketSplitter implements Iterable<PacketByteBuf> {
+public final class PacketSplitter implements Iterable<ByteBuf> {
 	public static final int CHUNK_SIZE = 32500;
 	public static final int HEADER_MAGIC = 1397771337 /* SPLI */;
 
@@ -49,26 +51,26 @@ public final class PacketSplitter implements Iterable<PacketByteBuf> {
 	}
 
 	@Override
-	public @NotNull Iterator<PacketByteBuf> iterator() {
+	public @NotNull Iterator<ByteBuf> iterator() {
 		if (source.getInt(source.readerIndex()) != HEADER_MAGIC) {
 			throw new MissingHeaderException();
 		}
 		return new BufferIterator();
 	}
 
-	private class BufferIterator implements Iterator<PacketByteBuf> {
+	private class BufferIterator implements Iterator<ByteBuf> {
 		@Override
 		public boolean hasNext() {
 			return source.readableBytes() > 0;
 		}
 
 		@Override
-		public PacketByteBuf next() {
+		public ByteBuf next() {
 			int length = Math.min(CHUNK_SIZE, source.readableBytes());
 			if (length <= 0) {
 				throw new NoSuchElementException();
 			}
-			return new PacketByteBuf(source.readSlice(length));
+			return source.readSlice(length);
 		}
 	}
 

--- a/src/main/resources/commandblockide.accesswidener
+++ b/src/main/resources/commandblockide.accesswidener
@@ -1,2 +1,4 @@
 accessWidener	v1	named
 accessible	class	net/minecraft/client/gui/EditBox$Substring
+
+accessible method net/minecraft/block/entity/CommandBlockBlockEntity readNbt (Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/registry/RegistryWrapper$WrapperLookup;)V


### PR DESCRIPTION
1.20.6 has been released and I need this mode with 1.20.6, so I update to 1.20.6 directly and make a pull request. 1.20.6 requires Java 21, so I also request the 21 update.

In 1.20.5, the networking logic was completely rewritten, so I rewrote the packet anew. There was a little bit of an ambiguity in the ApplyFunction packet, so please check the modified file.

I'm not very good at coding, so I'd appreciate it if you could look at the code with that in mind.