### PR TITLE
Update to 1.21.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,8 +50,10 @@ java {
     withSourcesJar()
 }
 
+
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
+    options.release = 21
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,12 +6,12 @@ loom_version=1.10.1
 shadow_version=7.1.2
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.10
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.16.14
 # Dependencies
 # check these on https://modmuss50.me/fabric.html
-fabric_version=0.119.6+1.21.5
+fabric_version=0.127.1+1.21.6
 msgpack_java_version=0.9.3
 # Test dependencies
 junit_version=5.9.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx2G
 # Gradle Plugins
 android_git_version_version=0.4.14
-loom_version=1.9-SNAPSHOT
+loom_version=1.10.1
 shadow_version=7.1.2
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
 loader_version=0.16.10
 # Dependencies
 # check these on https://modmuss50.me/fabric.html
-fabric_version=0.114.3+1.21.4
+fabric_version=0.119.6+1.21.5
 msgpack_java_version=0.9.3
 # Test dependencies
 junit_version=5.9.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/arm32x/minecraft/commandblockide/CommandBlockIDE.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/CommandBlockIDE.java
@@ -50,7 +50,7 @@ public final class CommandBlockIDE implements ModInitializer {
 				}
 
 				ServerPlayerEntity player = context.player();
-				MinecraftServer server = player.server;
+				MinecraftServer server = player.getServer();
 				server.execute(() -> {
 					Text feedbackMessage = FunctionIO.saveFunction(server, functionId, Arrays.asList(lines));
 					player.sendMessage(feedbackMessage);

--- a/src/main/java/arm32x/minecraft/commandblockide/Packets.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/Packets.java
@@ -3,9 +3,8 @@ package arm32x.minecraft.commandblockide;
 import arm32x.minecraft.commandblockide.payloads.ApplyFunctionPayload;
 import arm32x.minecraft.commandblockide.payloads.EditFunctionPayload;
 import arm32x.minecraft.commandblockide.payloads.UpdateFunctionCommandPayload;
+import net.minecraft.network.packet.CustomPayload.Id;
 import net.minecraft.util.Identifier;
-
-import static net.minecraft.network.packet.CustomPayload.Id;
 
 public final class Packets {
 	// Namespace

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
@@ -3,23 +3,29 @@ package arm32x.minecraft.commandblockide.client.gui;
 import arm32x.minecraft.commandblockide.mixin.client.EditBoxAccessor;
 import arm32x.minecraft.commandblockide.mixin.client.TextFieldWidgetAccessor;
 import arm32x.minecraft.commandblockide.util.OrderedTexts;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.EditBox;
+import net.minecraft.client.gui.render.state.ColoredQuadGuiElementRenderState;
 import net.minecraft.client.gui.screen.ChatInputSuggestor;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.input.CursorMovement;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
 import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.texture.TextureSetup;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
@@ -33,73 +39,74 @@ import org.lwjgl.glfw.GLFW;
 
 @Environment(EnvType.CLIENT)
 public class MultilineTextFieldWidget extends TextFieldWidget {
-	/**
-	 * Allows easy and convenient access to private fields in the superclass.
-	 */
-	private final TextFieldWidgetAccessor self = (TextFieldWidgetAccessor)this;
+    /**
+     * Allows easy and convenient access to private fields in the superclass.
+     */
+    private final TextFieldWidgetAccessor self = (TextFieldWidgetAccessor) this;
 
     // TODO: Allow the user to configure this or to indent with tabs.
     // Note that both the text field renderer and the command processor do not
     // support tabs yet.
-	private static final int INDENT_SIZE = 4;
+    private static final int INDENT_SIZE = 4;
 
-	// The amount of time the cursor will spend being either visible or
-	// invisible before switching to the other state.
+    // The amount of time the cursor will spend being either visible or
+    // invisible before switching to the other state.
     private static final long CURSOR_BLINK_INTERVAL_MS = 300;
 
-	private final EditBox editBox;
+    private final EditBox editBox;
 
-	private boolean horizontalScrollEnabled;
-	private int horizontalScroll = 0;
-	private boolean verticalScrollEnabled;
-	private int verticalScroll = 0;
-	public static final double SCROLL_SENSITIVITY = 15.0;
+    private boolean horizontalScrollEnabled;
+    private int horizontalScroll = 0;
+    private boolean verticalScrollEnabled;
+    private int verticalScroll = 0;
+    public static final double SCROLL_SENSITIVITY = 15.0;
 
-	private int lineHeight = 12;
-	private SyntaxHighlighter syntaxHighlighter = SyntaxHighlighter.NONE;
+    private int lineHeight = 12;
+    private SyntaxHighlighter syntaxHighlighter = SyntaxHighlighter.NONE;
 
-	private @Nullable Runnable cursorChangeListener = null;
+    private @Nullable Runnable cursorChangeListener = null;
 
-	public MultilineTextFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, Text text, boolean horizontalScrollEnabled, boolean verticalScrollEnabled) {
-		super(textRenderer, x, y, width, height, text);
-		this.horizontalScrollEnabled = horizontalScrollEnabled;
-		this.verticalScrollEnabled = verticalScrollEnabled;
+    public MultilineTextFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, Text text, boolean horizontalScrollEnabled, boolean verticalScrollEnabled) {
+        super(textRenderer, x, y, width, height, text);
+        this.horizontalScrollEnabled = horizontalScrollEnabled;
+        this.verticalScrollEnabled = verticalScrollEnabled;
 
-		// TODO: Support soft wrap.
-		editBox = new EditBox(textRenderer, Integer.MAX_VALUE);
-	}
+        // TODO: Support soft wrap.
+        editBox = new EditBox(textRenderer, Integer.MAX_VALUE);
+    }
 
-	public MultilineTextFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, Text text) {
-		this(textRenderer, x, y, width, height, text, true, true);
-		editBox.setCursorChangeListener(() -> {
-			scrollToEnsureCursorVisible();
-			if (cursorChangeListener != null) {
-				cursorChangeListener.run();
-			}
-		});
-	}
+    public MultilineTextFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, Text text) {
+        this(textRenderer, x, y, width, height, text, true, true);
+        editBox.setCursorChangeListener(() -> {
+            scrollToEnsureCursorVisible();
+            if (cursorChangeListener != null) {
+                cursorChangeListener.run();
+            }
+        });
+    }
 
-	@Override
-	public void setChangedListener(@Nullable Consumer<String> changedListener) {
-		editBox.setChangeListener(Objects.requireNonNullElseGet(changedListener, () -> text -> {}));
-	}
+    @Override
+    public void setChangedListener(@Nullable Consumer<String> changedListener) {
+        editBox.setChangeListener(Objects.requireNonNullElseGet(changedListener, () -> text -> {
+        }));
+    }
 
-	public void setCursorChangeListener(@Nullable Runnable cursorChangeListener) {
-		this.cursorChangeListener = cursorChangeListener;
-	}
+    public void setCursorChangeListener(@Nullable Runnable cursorChangeListener) {
+        this.cursorChangeListener = cursorChangeListener;
+    }
 
     @Override
     public void setText(String text) {
-        editBox.setText(text);
+        editBox.setText(text, true);
     }
 
-	@Override
-	public String getText() {
+    @Override
+    public String getText() {
         return editBox.getText();
     }
 
-	@Override
-	public String getSelectedText() {
+    @Override
+    public String getSelectedText() {
         return editBox.getSelectedText();
     }
 
@@ -108,12 +115,12 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
         throw new UnsupportedOperationException();
     }
 
-	@Override
+    @Override
     @Deprecated
-	public void setRenderTextProvider(BiFunction<String, Integer, OrderedText> renderTextProvider) {
-		// Do nothing. I would love to throw an UnsupportedOperationException,
-		// but this is called by ChatInputSuggestor.
-	}
+    public void setRenderTextProvider(BiFunction<String, Integer, OrderedText> renderTextProvider) {
+        // Do nothing. I would love to throw an UnsupportedOperationException,
+        // but this is called by ChatInputSuggestor.
+    }
 
     public SyntaxHighlighter getSyntaxHighlighter() {
         return syntaxHighlighter;
@@ -123,10 +130,10 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
         this.syntaxHighlighter = syntaxHighlighter;
     }
 
-	@Override
-	public void write(String text) {
+    @Override
+    public void write(String text) {
         editBox.replaceSelection(text);
-	}
+    }
 
     @Override
     public void eraseWords(int wordOffset) {
@@ -145,7 +152,7 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
 
     @Override
     public void moveCursor(int offset, boolean hasShiftDown) {
-		editBox.setSelecting(hasShiftDown);
+        editBox.setSelecting(hasShiftDown);
         editBox.moveCursor(CursorMovement.RELATIVE, offset);
     }
 
@@ -153,43 +160,43 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
         double virtualX = mouseX - getInnerX() + getHorizontalScroll();
         double virtualY = mouseY - getInnerY() + getVerticalScroll();
 
-		int lineIndex = MathHelper.floor(virtualY / getLineHeight());
+        int lineIndex = MathHelper.floor(virtualY / getLineHeight());
 
-		// Get a rough estimate of where the cursor should be.
-		EditBox.Substring lineSubstring = editBox.getLine(lineIndex);
-		String line = getText().substring(lineSubstring.beginIndex(), lineSubstring.endIndex());
-		int charIndexInLine = self.getTextRenderer().trimToWidth(line, MathHelper.floor(virtualX)).length();
-		int charIndex = lineSubstring.beginIndex() + charIndexInLine;
+        // Get a rough estimate of where the cursor should be.
+        EditBox.Substring lineSubstring = editBox.getLine(lineIndex);
+        String line = getText().substring(lineSubstring.beginIndex(), lineSubstring.endIndex());
+        int charIndexInLine = self.getTextRenderer().trimToWidth(line, MathHelper.floor(virtualX)).length();
+        int charIndex = lineSubstring.beginIndex() + charIndexInLine;
 
-		// Refine the estimate by determining the nearest character boundary.
-		double leftCharacterXDistance = Math.abs(getCharacterVirtualX(charIndex) - virtualX);
-		double rightCharacterXDistance = Math.abs(getCharacterVirtualX(charIndex + 1) - virtualX);
-		if (rightCharacterXDistance < leftCharacterXDistance) {
-			charIndex++;
-		}
+        // Refine the estimate by determining the nearest character boundary.
+        double leftCharacterXDistance = Math.abs(getCharacterVirtualX(charIndex) - virtualX);
+        double rightCharacterXDistance = Math.abs(getCharacterVirtualX(charIndex + 1) - virtualX);
+        if (rightCharacterXDistance < leftCharacterXDistance) {
+            charIndex++;
+        }
 
-		setCursor(charIndex, false);
+        setCursor(charIndex, false);
     }
 
     @Override
     public void setCursor(int cursor, boolean hasShiftDown) {
-		editBox.setSelecting(hasShiftDown);
+        editBox.setSelecting(hasShiftDown);
         editBox.moveCursor(CursorMovement.ABSOLUTE, cursor);
     }
 
     @Override
     public void setSelectionStart(int cursor) {
-		setCursor(cursor, true);
+        setCursor(cursor, true);
     }
 
-	@Override
-	public void setSelectionEnd(int index) {
-		((EditBoxAccessor)editBox).setSelectionEnd(index);
-	}
+    @Override
+    public void setSelectionEnd(int index) {
+        ((EditBoxAccessor) editBox).setSelectionEnd(index);
+    }
 
-	@Override
-	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-		if (keyCode == GLFW.GLFW_KEY_TAB) {
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (keyCode == GLFW.GLFW_KEY_TAB) {
             if (editBox.hasSelection()) {
                 logger.warn("Indenting selected lines is not yet supported");
             } else {
@@ -199,8 +206,8 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
             }
             return true;
         } else {
-			return editBox.handleSpecialKey(keyCode);
-		}
+            return editBox.handleSpecialKey(keyCode);
+        }
     }
 
     @Override
@@ -236,138 +243,116 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
         return false;
     }
 
-	@Override
-	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-		if (this.isMouseOver(mouseX, mouseY)) {
-			horizontalAmount = Screen.hasShiftDown() ? verticalAmount : horizontalAmount;
-			verticalAmount = Screen.hasShiftDown() ? 0 : verticalAmount;
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        if (this.isMouseOver(mouseX, mouseY)) {
+            horizontalAmount = Screen.hasShiftDown() ? verticalAmount : horizontalAmount;
+            verticalAmount = Screen.hasShiftDown() ? 0 : verticalAmount;
 
-			boolean changed = setHorizontalScroll(getHorizontalScroll() - (int)Math.round(horizontalAmount * SCROLL_SENSITIVITY));
-			changed = changed || setVerticalScroll(getVerticalScroll() - (int)Math.round(verticalAmount * SCROLL_SENSITIVITY));
+            boolean changed = setHorizontalScroll(getHorizontalScroll() - (int) Math.round(horizontalAmount * SCROLL_SENSITIVITY));
+            changed = changed || setVerticalScroll(getVerticalScroll() - (int) Math.round(verticalAmount * SCROLL_SENSITIVITY));
 
-			// This updates the position of the suggestions window.
-			if (cursorChangeListener != null) {
-				cursorChangeListener.run();
-			}
-			return changed;
-		} else {
-			return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
-		}
-	}
+            // This updates the position of the suggestions window.
+            if (cursorChangeListener != null) {
+                cursorChangeListener.run();
+            }
+            return changed;
+        } else {
+            return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+        }
+    }
 
-	@Override
-	public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
-		if (!isVisible()) {
-			return;
-		}
+    @Override
+    public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+        if (!isVisible()) {
+            return;
+        }
 
-		if (drawsBackground()) {
-			var textureId = TextFieldWidgetAccessor.getTextures().get(isNarratable(), isFocused());
-			context.drawGuiTexture(RenderLayer::getGuiTextured, textureId, getX(), getY(), getWidth(), getHeight());
-		}
+        if (drawsBackground()) {
+            var textureId = TextFieldWidgetAccessor.getTextures().get(isNarratable(), isFocused());
+            context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, textureId, getX(), getY(), getWidth(), getHeight());
+        }
 
-		context.enableScissor(
-			this.getX() + 1,
-			this.getY() + 1,
-			this.getX() + this.getWidth() - 1,
-			this.getY() + this.getHeight() - 1
-		);
+        context.enableScissor(
+                this.getX() + 1,
+                this.getY() + 1,
+                this.getX() + this.getWidth() - 1,
+                this.getY() + this.getHeight() - 1
+        );
 
-		int textColor = self.invokeIsEditable() ? self.getEditableColor() : self.getUneditableColor();
-		int x = getInnerX() - horizontalScroll;
-		int y = getInnerY() - verticalScroll;
+        int textColor = self.invokeIsEditable() ? self.getEditableColor() : self.getUneditableColor();
+        int x = getInnerX() - horizontalScroll;
+        int y = getInnerY() - verticalScroll;
 
-		long timeSinceLastSwitchFocusMs = Util.getMeasuringTimeMs() - self.getLastSwitchFocusTime();
+        long timeSinceLastSwitchFocusMs = Util.getMeasuringTimeMs() - self.getLastSwitchFocusTime();
         boolean showCursor = isFocused() && timeSinceLastSwitchFocusMs / CURSOR_BLINK_INTERVAL_MS % 2 == 0;
-		boolean lineCursor = getCursor() < getText().length() || getText().length() >= self.invokeGetMaxLength();
+        boolean lineCursor = getCursor() < getText().length() || getText().length() >= self.invokeGetMaxLength();
 
-		int cursorLine = getCurrentLineIndex();
-		int cursorX = x;
-		int cursorY = y + lineHeight * cursorLine;
+        int cursorLine = getCurrentLineIndex();
+        int cursorX = x;
+        int cursorY = y + lineHeight * cursorLine;
 
-		// This assumes that the highlighter returns the same characters as the
-		// original text, which is not enforced by the API.
-		List<OrderedText> lines = getSyntaxHighlighter().highlight(getText());
-		for (int index = 0; index < lines.size(); index++) {
-			OrderedText line = lines.get(index);
-			if (index == cursorLine) {
-				int indexOfLastNewlineBeforeCursor = getLineStartBefore(getCursor()) - 1;
-				int codePointsBeforeCursor;
-				if (indexOfLastNewlineBeforeCursor != -1) {
-					codePointsBeforeCursor = getText().codePointCount(indexOfLastNewlineBeforeCursor, Math.max(getCursor() - 1, 0));
-				} else {
-					codePointsBeforeCursor = getText().codePointCount(0, getCursor());
-				}
-				int endX = context.drawTextWithShadow(self.getTextRenderer(), OrderedTexts.limit(codePointsBeforeCursor, line), x, y + lineHeight * index, textColor) - 1;
-				context.drawTextWithShadow(self.getTextRenderer(), OrderedTexts.skip(codePointsBeforeCursor, line), endX, y + lineHeight * index, textColor);
-				cursorX = endX - 1;
-			} else {
-				context.drawTextWithShadow(self.getTextRenderer(), line, x, y + lineHeight * index, textColor);
-			}
-		}
+        // This assumes that the highlighter returns the same characters as the
+        // original text, which is not enforced by the API.
+        List<OrderedText> lines = getSyntaxHighlighter().highlight(getText());
+        for (int index = 0; index < lines.size(); index++) {
+            OrderedText line = lines.get(index);
+            if (index == cursorLine) {
+                int indexOfLastNewlineBeforeCursor = getLineStartBefore(getCursor()) - 1;
+                int codePointsBeforeCursor;
+                if (indexOfLastNewlineBeforeCursor != -1) {
+                    codePointsBeforeCursor = getText().codePointCount(indexOfLastNewlineBeforeCursor, Math.max(getCursor() - 1, 0));
+                } else {
+                    codePointsBeforeCursor = getText().codePointCount(0, getCursor());
+                }
+                cursorX = x + self.getTextRenderer().getWidth(OrderedTexts.limit(codePointsBeforeCursor, line)) - 1;
+            }
+            context.drawTextWithShadow(self.getTextRenderer(), line, x, y + lineHeight * index, textColor);
+        }
 
-		if (showCursor) {
-			if (lineCursor) {
-				context.fill(RenderLayer.getGuiOverlay(), cursorX, cursorY - 1, cursorX + 1, cursorY + 10, 0xFFD0D0D0);
-			} else {
-				context.drawTextWithShadow(self.getTextRenderer(), "_", cursorX + 1, cursorY, textColor);
-			}
-		}
+        if (showCursor) {
+            if (lineCursor) {
+                context.fill(RenderPipelines.GUI, cursorX, cursorY - 1, cursorX + 1, cursorY + 10, 0xFFD0D0D0);
+            } else {
+                context.drawTextWithShadow(self.getTextRenderer(), "_", cursorX + 1, cursorY, textColor);
+            }
+        }
 
-		if (isFocused() && editBox.hasSelection()) {
-			renderSelection(context, x, y);
-		}
+        if (isFocused() && editBox.hasSelection()) {
+            renderSelection(context, x, y);
+        }
 
-		context.disableScissor();
-	}
+        context.disableScissor();
+    }
 
-	private void renderSelection(DrawContext context, int x, int y) {
-		context.draw(vertexConsumers -> {
-			var selection = editBox.getSelection();
-			int normalizedSelectionStart = selection.beginIndex();
-			int normalizedSelectionEnd = selection.endIndex();
+    private void renderSelection(DrawContext context, int x, int y) {
+        var selection = editBox.getSelection();
+        int normalizedSelectionStart = selection.beginIndex();
+        int normalizedSelectionEnd = selection.endIndex();
 
-			int startX = x + self.getTextRenderer().getWidth(getText().substring(getLineStartBefore(normalizedSelectionStart), normalizedSelectionStart)) - 1;
-			int startY = y + lineHeight * getLineIndex(normalizedSelectionStart) - 1;
-			int endX = x + self.getTextRenderer().getWidth(getText().substring(getLineStartBefore(normalizedSelectionEnd), normalizedSelectionEnd)) - 1;
-			int endY = y + lineHeight * getLineIndex(normalizedSelectionEnd) - 1;
+        int startX = x + self.getTextRenderer().getWidth(getText().substring(getLineStartBefore(normalizedSelectionStart), normalizedSelectionStart)) - 1;
+        int startY = y + lineHeight * getLineIndex(normalizedSelectionStart) - 1;
+        int endX = x + self.getTextRenderer().getWidth(getText().substring(getLineStartBefore(normalizedSelectionEnd), normalizedSelectionEnd)) - 1;
+        int endY = y + lineHeight * getLineIndex(normalizedSelectionEnd) - 1;
 
-			int leftEdge = getInnerX();
-			int rightEdge = leftEdge + this.getInnerWidth();
+        int leftEdge = getInnerX();
+        int rightEdge = leftEdge + this.getInnerWidth();
 
-			Matrix4f matrix = context.getMatrices().peek().getPositionMatrix();
-			VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getGuiTextHighlight());
+        if (startY == endY) {
+            // Selection spans one line
+            context.fill(startX, startY, endX, endY + lineHeight - 1, 0x88EEEEEE);
+        } else {
+            // Selection spans two or more lines
+            context.fill(startX, startY, rightEdge, startY + lineHeight, 0x88EEEEEE);
 
-			float r = 0.0f, g = 0.0f, b = 1.0f, a = 1.0f;
+            if (!(startY - lineHeight == endY || endY - lineHeight == startY)) {
+                // Selection spans three or more lines
+                context.fill(leftEdge, startY + lineHeight, rightEdge, endY, 0x88EEEEEE);
+            }
 
-			if (startY == endY) {
-				// Selection spans one line
-				vertexConsumer.vertex(matrix, endX, startY, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, startX, startY, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, startX, endY + lineHeight - 1, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, endX, endY + lineHeight - 1, 0.0f).color(r, g, b, a);
-			} else {
-				// Selection spans two or more lines
-				vertexConsumer.vertex(matrix, rightEdge, startY, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, startX, startY, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, startX, startY + lineHeight, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, rightEdge, startY + lineHeight, 0.0f).color(r, g, b, a);
-
-				if (!(startY - lineHeight == endY || endY - lineHeight == startY)) {
-					// Selection spans three or more lines
-					vertexConsumer.vertex(matrix, rightEdge, startY + lineHeight, 0.0f).color(r, g, b, a);
-					vertexConsumer.vertex(matrix, leftEdge, startY + lineHeight, 0.0f).color(r, g, b, a);
-					vertexConsumer.vertex(matrix, leftEdge, endY, 0.0f).color(r, g, b, a);
-					vertexConsumer.vertex(matrix, rightEdge, endY, 0.0f).color(r, g, b, a);
-				}
-
-				vertexConsumer.vertex(matrix, endX, endY, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, leftEdge, endY, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, leftEdge, endY + lineHeight - 1, 0.0f).color(r, g, b, a);
-				vertexConsumer.vertex(matrix, endX, endY + lineHeight - 1, 0.0f).color(r, g, b, a);
-			}
-		});
-	}
+            context.fill(leftEdge, endY, endX, endY + lineHeight - 1, 0x88EEEEEE);
+        }
+    }
 
     @Override
     public void setMaxLength(int maxLength) {
@@ -379,182 +364,182 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
         return editBox.getCursor();
     }
 
-	public int getLineCount() {
+    public int getLineCount() {
         return editBox.getLineCount();
-	}
+    }
 
-	public int getCurrentLineIndex() {
-		return getLineIndex(getCursor());
-	}
+    public int getCurrentLineIndex() {
+        return getLineIndex(getCursor());
+    }
 
-	private int getLineIndex(int charIndex) {
-		return (int)getText()
-			.substring(0, charIndex)
-			.codePoints()
-			.filter(point -> point == '\n')
-			.count();
-	}
+    private int getLineIndex(int charIndex) {
+        return (int) getText()
+                .substring(0, charIndex)
+                .codePoints()
+                .filter(point -> point == '\n')
+                .count();
+    }
 
-	private int getLineStartBefore(int charIndex) {
-		return getText().lastIndexOf('\n', Math.max(charIndex, 0) - 1) + 1;
-	}
+    private int getLineStartBefore(int charIndex) {
+        return getText().lastIndexOf('\n', Math.max(charIndex, 0) - 1) + 1;
+    }
 
     // Naming things is hard.
     public boolean isBeforeFirstNonWhitespaceCharacterInLine(int charIndex) {
         return getText()
-            .substring(getLineStartBefore(charIndex), charIndex)
-            .chars()
-            .allMatch(Character::isWhitespace);
+                .substring(getLineStartBefore(charIndex), charIndex)
+                .chars()
+                .allMatch(Character::isWhitespace);
     }
 
-	public String getLine(int lineIndex) {
-		var line = editBox.getLine(lineIndex);
-		return getText().substring(line.beginIndex(), line.endIndex());
-	}
+    public String getLine(int lineIndex) {
+        var line = editBox.getLine(lineIndex);
+        return getText().substring(line.beginIndex(), line.endIndex());
+    }
 
-	protected int getHorizontalScroll() {
-		return horizontalScroll;
-	}
+    protected int getHorizontalScroll() {
+        return horizontalScroll;
+    }
 
-	protected int getMaxHorizontalScroll() {
-		return Math.max(0, Arrays.stream(getText().split("\n"))
-			.mapToInt(self.getTextRenderer()::getWidth)
-			.max()
-			.orElse(0) + 8 - width);
-	}
+    protected int getMaxHorizontalScroll() {
+        return Math.max(0, Arrays.stream(getText().split("\n"))
+                .mapToInt(self.getTextRenderer()::getWidth)
+                .max()
+                .orElse(0) + 8 - width);
+    }
 
-	protected boolean setHorizontalScroll(int horizontalScroll) {
-		int previous = this.horizontalScroll;
-		this.horizontalScroll = MathHelper.clamp(horizontalScroll, 0, getMaxHorizontalScroll());
-		return this.horizontalScroll != previous;
-	}
+    protected boolean setHorizontalScroll(int horizontalScroll) {
+        int previous = this.horizontalScroll;
+        this.horizontalScroll = MathHelper.clamp(horizontalScroll, 0, getMaxHorizontalScroll());
+        return this.horizontalScroll != previous;
+    }
 
-	protected int getVerticalScroll() {
-		return verticalScroll;
-	}
+    protected int getVerticalScroll() {
+        return verticalScroll;
+    }
 
-	protected int getMaxVerticalScroll() {
-		return Math.max(0, getLineCount() * getLineHeight() + 2 - height);
-	}
+    protected int getMaxVerticalScroll() {
+        return Math.max(0, getLineCount() * getLineHeight() + 2 - height);
+    }
 
-	protected boolean setVerticalScroll(int verticalScroll) {
-		int previous = this.verticalScroll;
-		this.verticalScroll = MathHelper.clamp(verticalScroll, 0, getMaxVerticalScroll());
-		return this.verticalScroll != previous;
-	}
+    protected boolean setVerticalScroll(int verticalScroll) {
+        int previous = this.verticalScroll;
+        this.verticalScroll = MathHelper.clamp(verticalScroll, 0, getMaxVerticalScroll());
+        return this.verticalScroll != previous;
+    }
 
-	public boolean isHorizontalScrollEnabled() {
-		return horizontalScrollEnabled;
-	}
+    public boolean isHorizontalScrollEnabled() {
+        return horizontalScrollEnabled;
+    }
 
-	public void setHorizontalScrollEnabled(boolean enabled) {
-		horizontalScrollEnabled = enabled;
-		horizontalScroll = 0;
-	}
+    public void setHorizontalScrollEnabled(boolean enabled) {
+        horizontalScrollEnabled = enabled;
+        horizontalScroll = 0;
+    }
 
-	public boolean isVerticalScrollEnabled() {
-		return verticalScrollEnabled;
-	}
+    public boolean isVerticalScrollEnabled() {
+        return verticalScrollEnabled;
+    }
 
-	public void setVerticalScrollEnabled(boolean enabled) {
-		verticalScrollEnabled = enabled;
-		verticalScroll = 0;
-	}
+    public void setVerticalScrollEnabled(boolean enabled) {
+        verticalScrollEnabled = enabled;
+        verticalScroll = 0;
+    }
 
-	protected void scrollToEnsureCursorVisible() {
-		int virtualX = getCharacterVirtualX(getCursor());
-		int virtualY = getCharacterVirtualY(getCursor());
+    protected void scrollToEnsureCursorVisible() {
+        int virtualX = getCharacterVirtualX(getCursor());
+        int virtualY = getCharacterVirtualY(getCursor());
 
-		setHorizontalScroll(MathHelper.clamp(horizontalScroll, virtualX - getInnerWidth(), virtualX));
-		setVerticalScroll(MathHelper.clamp(verticalScroll, virtualY - getInnerHeight(), virtualY));
-	}
+        setHorizontalScroll(MathHelper.clamp(horizontalScroll, virtualX - getInnerWidth(), virtualX));
+        setVerticalScroll(MathHelper.clamp(verticalScroll, virtualY - getInnerHeight(), virtualY));
+    }
 
-	public int getLineHeight() {
-		return lineHeight;
-	}
+    public int getLineHeight() {
+        return lineHeight;
+    }
 
-	public void setLineHeight(int lineHeight) {
-		this.lineHeight = lineHeight;
-	}
+    public void setLineHeight(int lineHeight) {
+        this.lineHeight = lineHeight;
+    }
 
     public int getCharacterVirtualX(int charIndex) {
-		if (charIndex > getText().length()) {
-			return 0;
-		}
-		String line = getLine(getLineIndex(charIndex));
+        if (charIndex > getText().length()) {
+            return 0;
+        }
+        String line = getLine(getLineIndex(charIndex));
 
-		int indexInLine = charIndex - getLineStartBefore(charIndex);
-		if (indexInLine > line.length()) {
-			indexInLine = line.length();
-		}
+        int indexInLine = charIndex - getLineStartBefore(charIndex);
+        if (indexInLine > line.length()) {
+            indexInLine = line.length();
+        }
 
-		return self.getTextRenderer().getWidth(line.substring(0, indexInLine));
-	}
+        return self.getTextRenderer().getWidth(line.substring(0, indexInLine));
+    }
 
-	public int getCharacterRealX(int charIndex) {
-		return getInnerX() - horizontalScroll + getCharacterVirtualX(charIndex);
-	}
+    public int getCharacterRealX(int charIndex) {
+        return getInnerX() - horizontalScroll + getCharacterVirtualX(charIndex);
+    }
 
-	/**
-	 * Gets the desired X position of the {@link ChatInputSuggestor} window.
-	 *
-	 * <p>This function is marked as deprecated because it <i>does not do what
-	 * the method name says</i> and is only here to be called by
-	 * {@code ChatInputSuggestor}.</p>
-	 *
-	 * @param charIndex The index of the character to place the suggestion
-	 *                  window at.
-	 * @return The desired X position of the suggestion window.
-	 */
-	@Deprecated
-	@Override
-	public int getCharacterX(int charIndex) {
-		// Since getInnerX isn't a method in the original TextFieldWidget,
-		// ChatInputSuggestor calls getCharacterX(0) instead.
-		if (charIndex == 0) {
-			return getInnerX();
-		}
-		// Enforce a lower bound on position. ChatInputSuggestor will enforce
-		// the upper bound using getInnerWidth().
-		return Math.max(getCharacterRealX(charIndex), getInnerX());
-	}
+    /**
+     * Gets the desired X position of the {@link ChatInputSuggestor} window.
+     *
+     * <p>This function is marked as deprecated because it <i>does not do what
+     * the method name says</i> and is only here to be called by
+     * {@code ChatInputSuggestor}.</p>
+     *
+     * @param charIndex The index of the character to place the suggestion
+     *                  window at.
+     * @return The desired X position of the suggestion window.
+     */
+    @Deprecated
+    @Override
+    public int getCharacterX(int charIndex) {
+        // Since getInnerX isn't a method in the original TextFieldWidget,
+        // ChatInputSuggestor calls getCharacterX(0) instead.
+        if (charIndex == 0) {
+            return getInnerX();
+        }
+        // Enforce a lower bound on position. ChatInputSuggestor will enforce
+        // the upper bound using getInnerWidth().
+        return Math.max(getCharacterRealX(charIndex), getInnerX());
+    }
 
-	public int getCharacterVirtualY(int charIndex) {
-		if (charIndex > getText().length()) {
-			charIndex = getText().length();
-		}
-		int lineIndex = getLineIndex(charIndex);
+    public int getCharacterVirtualY(int charIndex) {
+        if (charIndex > getText().length()) {
+            charIndex = getText().length();
+        }
+        int lineIndex = getLineIndex(charIndex);
 
-		return lineIndex * getLineHeight();
-	}
+        return lineIndex * getLineHeight();
+    }
 
-	public int getCharacterRealY(int charIndex) {
-		return getInnerY() - verticalScroll + getCharacterVirtualY(charIndex);
-	}
+    public int getCharacterRealY(int charIndex) {
+        return getInnerY() - verticalScroll + getCharacterVirtualY(charIndex);
+    }
 
-	private int getInnerX() {
-		return this.getX() + (drawsBackground() ? 4 : 0);
-	}
+    private int getInnerX() {
+        return this.getX() + (drawsBackground() ? 4 : 0);
+    }
 
-	private int getInnerY() {
-		return this.getY() + (drawsBackground() ? 4 : 0);
-	}
+    private int getInnerY() {
+        return this.getY() + (drawsBackground() ? 4 : 0);
+    }
 
-	private int getInnerHeight() {
-		return drawsBackground() ? this.height - 6 : this.height;
-	}
+    private int getInnerHeight() {
+        return drawsBackground() ? this.height - 6 : this.height;
+    }
 
     private static final Logger logger = LogManager.getLogger();
 
-	@FunctionalInterface
-	public interface SyntaxHighlighter {
+    @FunctionalInterface
+    public interface SyntaxHighlighter {
         /**
          * A syntax highlighter that performs no highlighting.
          */
-		SyntaxHighlighter NONE = text -> Arrays.stream(text.split("\n"))
-            .map(line -> OrderedText.styledForwardsVisitedString(line, Style.EMPTY))
-            .toList();
+        SyntaxHighlighter NONE = text -> Arrays.stream(text.split("\n"))
+                .map(line -> OrderedText.styledForwardsVisitedString(line, Style.EMPTY))
+                .toList();
 
-		List<OrderedText> highlight(String text);
-	}
+        List<OrderedText> highlight(String text);
+    }
 }

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/CommandBlockTypeButton.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/CommandBlockTypeButton.java
@@ -2,7 +2,6 @@ package arm32x.minecraft.commandblockide.client.gui.button;
 
 import arm32x.minecraft.commandblockide.client.Dirtyable;
 import arm32x.minecraft.commandblockide.mixin.client.DrawContextAccessor;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
@@ -11,7 +10,6 @@ import net.minecraft.client.render.*;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-import org.joml.Matrix4f;
 
 public final class CommandBlockTypeButton extends IconButton implements Dirtyable {
 	private CommandBlockBlockEntity.Type type = CommandBlockBlockEntity.Type.REDSTONE;
@@ -80,10 +78,6 @@ public final class CommandBlockTypeButton extends IconButton implements Dirtyabl
 	public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
 		var texture = getTexture();
 
-		RenderSystem.enableBlend();
-		RenderSystem.defaultBlendFunc();
-		RenderSystem.enableDepthTest();
-
 		int color = active ? 0xFFFFFFFF : 0x7FFFFFFF;
 		int shadowColor = 0x3F000000;
 
@@ -97,9 +91,6 @@ public final class CommandBlockTypeButton extends IconButton implements Dirtyabl
 		int x1 = getX(), x2 = x1 + 16, y1 = getY(), y2 = y1 + 16;
 		float u1 = 0.0f, u2 = 1.0f, v1 = 0.0f, v2 = 0.25f;
 		((DrawContextAccessor)context).invokeDrawTexturedQuad(RenderLayer::getGuiTextured, texture, x1, x2, y1, y2, u2, u1, v2, v1, color);
-
-		RenderSystem.disableDepthTest();
-		RenderSystem.disableBlend();
 	}
 
 	@Override

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/CommandBlockTypeButton.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/CommandBlockTypeButton.java
@@ -2,7 +2,9 @@ package arm32x.minecraft.commandblockide.client.gui.button;
 
 import arm32x.minecraft.commandblockide.client.Dirtyable;
 import arm32x.minecraft.commandblockide.mixin.client.DrawContextAccessor;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.tooltip.Tooltip;
@@ -82,7 +84,7 @@ public final class CommandBlockTypeButton extends IconButton implements Dirtyabl
 		int shadowColor = 0x3F000000;
 
 		if (active) {
-			context.drawTexture(RenderLayer::getGuiTextured, texture, getX() + 1, getY() + 1, 0, 0, iconWidth, iconHeight, 16, 64, shadowColor);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, texture, getX() + 1, getY() + 1, 0, 0, iconWidth, iconHeight, 16, 64, shadowColor);
 		}
 
 		// To flip the texture, we pass u2, u1, v2, v1 instead of the usual
@@ -90,7 +92,7 @@ public final class CommandBlockTypeButton extends IconButton implements Dirtyabl
 		// instead of going through context.drawTexture.
 		int x1 = getX(), x2 = x1 + 16, y1 = getY(), y2 = y1 + 16;
 		float u1 = 0.0f, u2 = 1.0f, v1 = 0.0f, v2 = 0.25f;
-		((DrawContextAccessor)context).invokeDrawTexturedQuad(RenderLayer::getGuiTextured, texture, x1, x2, y1, y2, u2, u1, v2, v1, color);
+		((DrawContextAccessor)context).invokeDrawTexturedQuad(RenderPipelines.GUI_TEXTURED, texture, x1, x2, y1, y2, u2, u1, v2, v1, color);
 	}
 
 	@Override

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/IconButton.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/IconButton.java
@@ -1,5 +1,6 @@
 package arm32x.minecraft.commandblockide.client.gui.button;
 
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.widget.PressableWidget;
@@ -59,16 +60,16 @@ public abstract class IconButton extends PressableWidget {
 			int color = ColorHelper.fromFloats(1.0f, brightness, brightness, brightness);
 			int shadowColor = ColorHelper.fromFloats(1.0f, brightness / 4, brightness / 4, brightness / 4);
 
-			context.drawTexture(RenderLayer::getGuiTextured, texture, iconX + 1, iconY + 1, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, shadowColor);
-			context.drawTexture(RenderLayer::getGuiTextured, texture, iconX, iconY, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, color);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, texture, iconX + 1, iconY + 1, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, shadowColor);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, texture, iconX, iconY, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, color);
 		} else {
 			int color = active ? 0xFFFFFFFF : 0x7FFFFFFF;
 			int shadowColor = 0x3F000000;
 
 			if (active) {
-				context.drawTexture(RenderLayer::getGuiTextured, texture, iconX + 1, iconY + 1, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, shadowColor);
+				context.drawTexture(RenderPipelines.GUI_TEXTURED, texture, iconX + 1, iconY + 1, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, shadowColor);
 			}
-			context.drawTexture(RenderLayer::getGuiTextured, texture, iconX, iconY, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, color);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, texture, iconX, iconY, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, color);
 		}
 	}
 

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/IconButton.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/button/IconButton.java
@@ -1,6 +1,5 @@
 package arm32x.minecraft.commandblockide.client.gui.button;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.widget.PressableWidget;
@@ -63,10 +62,6 @@ public abstract class IconButton extends PressableWidget {
 			context.drawTexture(RenderLayer::getGuiTextured, texture, iconX + 1, iconY + 1, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, shadowColor);
 			context.drawTexture(RenderLayer::getGuiTextured, texture, iconX, iconY, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, color);
 		} else {
-			RenderSystem.enableBlend();
-			RenderSystem.defaultBlendFunc();
-			RenderSystem.enableDepthTest();
-
 			int color = active ? 0xFFFFFFFF : 0x7FFFFFFF;
 			int shadowColor = 0x3F000000;
 
@@ -74,9 +69,6 @@ public abstract class IconButton extends PressableWidget {
 				context.drawTexture(RenderLayer::getGuiTextured, texture, iconX + 1, iconY + 1, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, shadowColor);
 			}
 			context.drawTexture(RenderLayer::getGuiTextured, texture, iconX, iconY, 0, 0, iconWidth, iconHeight, iconWidth, iconHeight, color);
-
-			RenderSystem.disableDepthTest();
-			RenderSystem.disableBlend();
 		}
 	}
 

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/editor/CommandEditor.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/editor/CommandEditor.java
@@ -204,10 +204,10 @@ public abstract class CommandEditor extends Container implements Dirtyable {
 	public void renderSuggestions(DrawContext context, int mouseX, int mouseY) {
 		if (commandField.isActive()) {
 			var matrices = context.getMatrices();
-			matrices.push();
-			matrices.translate(0.0, 0.0, 50.0);
+			matrices.pushMatrix();
+			matrices.translate(0.0f, 0.0f);
 			suggestor.render(context, mouseX, mouseY);
-			matrices.pop();
+			matrices.popMatrix();
 		}
 	}
 

--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/screen/CommandIDEScreen.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/screen/CommandIDEScreen.java
@@ -22,6 +22,7 @@ import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix3x2f;
 import org.joml.Vector2i;
 import org.lwjgl.glfw.GLFW;
 
@@ -358,15 +359,15 @@ public abstract class CommandIDEScreen<E extends CommandEditor> extends Screen i
 		}
 
 		var matrices = context.getMatrices();
-		matrices.push();
-		matrices.translate(0.0, 0.0, 10.0);
+		matrices.pushMatrix();
+		matrices.translate(0.0f, 0.0f, new Matrix3x2f());
 
 		super.render(context, mouseX, mouseY, delta);
 		if (statusText != null) {
-			context.drawTooltip(textRenderer, List.of(statusText), STATUS_TEXT_POSITIONER, statusTextX + 5, height - 22);
+			context.drawTooltip(List.of(statusText), statusTextX + 5, height - 22);
 		}
 
-		matrices.pop();
+		matrices.popMatrix();
 	}
 
 	@Override

--- a/src/main/java/arm32x/minecraft/commandblockide/client/update/DataCommandUpdateRequester.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/update/DataCommandUpdateRequester.java
@@ -75,7 +75,7 @@ public final class DataCommandUpdateRequester {
 		String stringifiedTag = ((Text)args[3]).getString();
 		@Nullable NbtCompound tag;
 		try {
-			tag = StringNbtReader.parse(stringifiedTag);
+			tag = StringNbtReader.readCompound(stringifiedTag);
 		} catch (CommandSyntaxException ex) {
 			LOGGER.error("Error parsing feedback from data command.", ex);
 			return false;

--- a/src/main/java/arm32x/minecraft/commandblockide/client/update/DataCommandUpdateRequester.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/update/DataCommandUpdateRequester.java
@@ -1,109 +1,120 @@
 package arm32x.minecraft.commandblockide.client.update;
 
 import static arm32x.minecraft.commandblockide.client.CommandChainTracer.isCommandBlock;
+
+import arm32x.minecraft.commandblockide.CommandBlockIDE;
+import arm32x.minecraft.commandblockide.client.CommandBlockIDEClient;
 import arm32x.minecraft.commandblockide.client.gui.screen.CommandBlockIDEScreen;
 import arm32x.minecraft.commandblockide.mixin.client.CommandBlockBlockEntityAccessor;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import com.mojang.logging.LogUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.StringNbtReader;
+import net.minecraft.storage.NbtReadView;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableTextContent;
+import net.minecraft.util.ErrorReporter;
 import net.minecraft.util.math.BlockPos;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 public final class DataCommandUpdateRequester {
-	private static @Nullable DataCommandUpdateRequester INSTANCE = null;
+    private static @Nullable DataCommandUpdateRequester INSTANCE = null;
 
-	private final Map<BlockPos, CommandBlockBlockEntity> blocksToUpdate = new HashMap<>();
+    private final Map<BlockPos, CommandBlockBlockEntity> blocksToUpdate = new HashMap<>();
 
-	private DataCommandUpdateRequester() { }
+    private DataCommandUpdateRequester() {
+    }
 
-	public static DataCommandUpdateRequester getInstance() {
-		if (INSTANCE == null) {
-			return INSTANCE = new DataCommandUpdateRequester();
-		} else {
-			return INSTANCE;
-		}
-	}
+    public static DataCommandUpdateRequester getInstance() {
+        if (INSTANCE == null) {
+            return INSTANCE = new DataCommandUpdateRequester();
+        } else {
+            return INSTANCE;
+        }
+    }
 
-	public void requestUpdate(ClientPlayerEntity player, CommandBlockBlockEntity blockEntity) {
-		BlockPos position = blockEntity.getPos();
-		blocksToUpdate.put(position, blockEntity);
+    public void requestUpdate(ClientPlayerEntity player, CommandBlockBlockEntity blockEntity) {
+        BlockPos position = blockEntity.getPos();
+        blocksToUpdate.put(position, blockEntity);
 
-		String command = String.format("data get block %d %d %d", position.getX(), position.getY(), position.getZ());
-		player.networkHandler.sendCommand(command);
-	}
+        String command = String.format("data get block %d %d %d", position.getX(), position.getY(), position.getZ());
+        player.networkHandler.sendChatCommand(command);
+    }
 
-	public boolean handleFeedback(MinecraftClient client, TranslatableTextContent message) {
-		Object[] args = message.getArgs();
-		LOGGER.trace("Handling feedback for message {} with args {}.", message, args);
+    public boolean handleFeedback(MinecraftClient client, TranslatableTextContent message) {
+        Object[] args = message.getArgs();
+        LOGGER.trace("Handling feedback for message {} with args {}.", message, args);
 
-		@Nullable BlockPos position;
-		try {
-			position = new BlockPos((int)args[0], (int)args[1], (int)args[2]);
-		} catch (ClassCastException ex1) {
-			try {
-				position = new BlockPos(Integer.parseInt(getStringFromText(args[0])), Integer.parseInt(getStringFromText(args[1])), Integer.parseInt(getStringFromText(args[2])));
-			} catch (ClassCastException | NumberFormatException ex2) {
-				LOGGER.error("Could not get block position from command feedback.");
-				return false;
-			}
-		}
-		if (!blocksToUpdate.containsKey(position)) {
-			LOGGER.debug("Block {} not queued for update.", position);
-			return false;
-		}
+        @Nullable BlockPos position;
+        try {
+            position = new BlockPos((int) args[0], (int) args[1], (int) args[2]);
+        } catch (ClassCastException ex1) {
+            try {
+                position = new BlockPos(Integer.parseInt(getStringFromText(args[0])), Integer.parseInt(getStringFromText(args[1])), Integer.parseInt(getStringFromText(args[2])));
+            } catch (ClassCastException | NumberFormatException ex2) {
+                LOGGER.error("Could not get block position from command feedback.");
+                return false;
+            }
+        }
+        if (!blocksToUpdate.containsKey(position)) {
+            LOGGER.debug("Block {} not queued for update.", position);
+            return false;
+        }
 
-		if (client.world == null) {
-			LOGGER.warn("Client is outside of a world.");
-			return false;
-		}
-		BlockState blockState = client.world.getBlockState(position);
-		if (!isCommandBlock(blockState)) {
-			LOGGER.debug("Block {} is not a command block.", position);
-			return false;
-		}
+        if (client.world == null) {
+            LOGGER.warn("Client is outside of a world.");
+            return false;
+        }
+        BlockState blockState = client.world.getBlockState(position);
+        if (!isCommandBlock(blockState)) {
+            LOGGER.debug("Block {} is not a command block.", position);
+            return false;
+        }
 
-		String stringifiedTag = ((Text)args[3]).getString();
-		@Nullable NbtCompound tag;
-		try {
-			tag = StringNbtReader.readCompound(stringifiedTag);
-		} catch (CommandSyntaxException ex) {
-			LOGGER.error("Error parsing feedback from data command.", ex);
-			return false;
-		}
+        String stringifiedTag = ((Text) args[3]).getString();
+        @Nullable NbtCompound tag;
+        try {
+            tag = StringNbtReader.readCompound(stringifiedTag);
+        } catch (CommandSyntaxException ex) {
+            LOGGER.error("Error parsing feedback from data command.", ex);
+            return false;
+        }
 
-		@Nullable CommandBlockBlockEntity blockEntity = blocksToUpdate.get(position);
-		if (blockEntity == null) {
-			LOGGER.debug("Block entity {} not queued for update.", position);
-			return false;
-		}
+        @Nullable CommandBlockBlockEntity blockEntity = blocksToUpdate.get(position);
+        if (blockEntity == null) {
+            LOGGER.debug("Block entity {} not queued for update.", position);
+            return false;
+        }
 
-		((CommandBlockBlockEntityAccessor)blockEntity).invokeReadNbt(tag, client.world.getRegistryManager());
-//		blockEntity.setNeedsUpdatePacket(false);
-		if (client.currentScreen instanceof CommandBlockIDEScreen) {
-			((CommandBlockIDEScreen)client.currentScreen).update(position);
-		}
-		blocksToUpdate.remove(position);
+        try (ErrorReporter.Logging logging = new ErrorReporter.Logging(blockEntity.getReporterContext(), LogUtils.getLogger())) {
+            ((CommandBlockBlockEntityAccessor) blockEntity).invokeReadData(NbtReadView.create(logging, client.world.getRegistryManager(), tag));
+        }
 
-		return true;
-	}
+        if (client.currentScreen instanceof CommandBlockIDEScreen) {
+            ((CommandBlockIDEScreen) client.currentScreen).update(position);
+        }
+        blocksToUpdate.remove(position);
 
-	private static String getStringFromText(Object object) {
-		if (object instanceof Text text) {
-			return text.getString();
-		} else {
-			return object.toString();
-		}
-	}
+        return true;
+    }
 
-	private static final Logger LOGGER = LogManager.getLogger();
+    private static String getStringFromText(Object object) {
+        if (object instanceof Text text) {
+            return text.getString();
+        } else {
+            return object.toString();
+        }
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger();
 }

--- a/src/main/java/arm32x/minecraft/commandblockide/mixin/client/CommandBlockBlockEntityAccessor.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/mixin/client/CommandBlockBlockEntityAccessor.java
@@ -5,11 +5,12 @@ import net.fabricmc.api.Environment;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.storage.ReadView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Environment(EnvType.CLIENT)
 @Mixin(CommandBlockBlockEntity.class)
 public interface CommandBlockBlockEntityAccessor {
-    @Invoker void invokeReadNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup);
+    @Invoker void invokeReadData(ReadView view);
 }

--- a/src/main/java/arm32x/minecraft/commandblockide/mixin/client/DrawContextAccessor.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/mixin/client/DrawContextAccessor.java
@@ -1,6 +1,8 @@
 package arm32x.minecraft.commandblockide.mixin.client;
 
 import java.util.function.Function;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.DrawContext;
@@ -12,5 +14,5 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 @Environment(EnvType.CLIENT)
 @Mixin(DrawContext.class)
 public interface DrawContextAccessor {
-    @Invoker void invokeDrawTexturedQuad(Function<Identifier, RenderLayer> renderLayers, Identifier sprite, int x1, int x2, int y1, int y2, float u1, float u2, float v1, float v2, int color);
+    @Invoker void invokeDrawTexturedQuad(RenderPipeline pipeline, Identifier sprite, int x1, int x2, int y1, int y2, float u1, float u2, float v1, float v2, int color);
 }

--- a/src/main/java/arm32x/minecraft/commandblockide/server/function/FunctionIO.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/server/function/FunctionIO.java
@@ -16,7 +16,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.PathUtil;
+import net.minecraft.util.path.PathUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
It has 1.21.6 support now. A lot of the code needed to be ported to use the new RenderLayers system, and since `DrawContext::draw` doesn't exist anymore, the highlighting code needed to be ported to use `DrawContext::fill` instead.

I don't think there are any regressions, I tested it and it all seemed to work. However the highlighting code is slightly different since I couldn't get drawing directly to the GUI_TEXT_HIGHLIGHT RenderLayer (I tried but the highlight just didn't show up?) so the color is slightly off, although I don't think it's that big of a deal.

Also apologies for the massive diff on DataCommandUpdateRequester, it seems like that file was using tabs while the rest of the project was using spaces and I ran a formatter on it at one point.

I don't think there are any regressions, I tested it and it all seemed to work. However the highlighting code is slightly different since I couldn't get drawing directly to the GUI_TEXT_HIGHLIGHT RenderLayer (I tried but the highlight just didn't show up?) so the color is slightly off, although I don't think it's that big of a deal.

This merge request also includes #66 for 1.21.5 support.

Made with help from @myriantics and @valsei.